### PR TITLE
Added promregator hostname for discovery

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,10 @@ resource "cloudfoundry_app" "promregator" {
     password = var.docker_password
   }
   environment = merge(local.targets, {
-    CF_API_HOST = var.cf_api_host
-    CF_USERNAME = var.cf_username
-    CF_PASSWORD = var.cf_password
+    CF_API_HOST                    = var.cf_api_host
+    CF_USERNAME                    = var.cf_username
+    CF_PASSWORD                    = var.cf_password
+    PROMREGATOR_DISCOVERY_HOSTNAME = cloudfoundry_route.promregator.endpoint
   }, var.environment)
 
   routes {

--- a/variables.tf
+++ b/variables.tf
@@ -58,5 +58,5 @@ variable "environment" {
 }
 variable "promregator_targets" {
   description = "A list of maps representing the properties of the target to be configured. These are the config values from propergator targets"
-  type        = list(map(any))    
+  type        = list(map(any))
 }


### PR DESCRIPTION
The discovery hostname was defaulting to the hostname in the container which was not correct. Added in an override of the hostname to the configured route.